### PR TITLE
Add OS/Arch to useragent string for Duo so that 'otheros' isn't needed

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ require (
 	github.com/99designs/keyring v1.0.0
 	github.com/alessio/shellescape v0.0.0-20190409004728-b115ca0f9053
 	github.com/aws/aws-sdk-go v1.25.25
+	github.com/beiriannydd/useragent v1.0.2
 	github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 // indirect
 	github.com/inconshreveable/mousetrap v1.0.0 // indirect
 	github.com/karalabe/hid v1.0.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,6 +4,10 @@ github.com/alessio/shellescape v0.0.0-20190409004728-b115ca0f9053 h1:H/GMMKYPkEI
 github.com/alessio/shellescape v0.0.0-20190409004728-b115ca0f9053/go.mod h1:xW8sBma2LE3QxFSzCnH9qe6gAE2yO9GvQaWwX89HxbE=
 github.com/aws/aws-sdk-go v1.25.25 h1:j3HLOqcDWjNox1DyvJRs+kVQF42Ghtv6oL6cVBfXS3U=
 github.com/aws/aws-sdk-go v1.25.25/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
+github.com/beiriannydd/useragent v1.0.1 h1:KzvSWgwrtyC7c0ZWfu2KAx+I39cVuZ5gFfRJYRCK0fI=
+github.com/beiriannydd/useragent v1.0.1/go.mod h1:tsWZrxEludQcRtcM2xG6ra1xQ2idI6kKyYTB6T6WhG0=
+github.com/beiriannydd/useragent v1.0.2 h1:JyXOEyS1ge4P3td96VmI6+4OFlPv6Oxi15vDx2IpTBM=
+github.com/beiriannydd/useragent v1.0.2/go.mod h1:tsWZrxEludQcRtcM2xG6ra1xQ2idI6kKyYTB6T6WhG0=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869 h1:DDGfHa7BWjL4YnC6+E63dPcxHo2sUxDIu8g3QgEJdRY=
 github.com/bmizerany/assert v0.0.0-20160611221934-b7ed37b82869/go.mod h1:Ekp36dRnpXw/yCqJaO+ZrUyxD+3VXMFFr56k5XYrpB4=
 github.com/danieljoos/wincred v1.0.2 h1:zf4bhty2iLuwgjgpraD2E9UbvO+fe54XXGJbOwe23fU=

--- a/lib/duo.go
+++ b/lib/duo.go
@@ -19,8 +19,11 @@ import (
 
 	uniformResourceLocator "net/url"
 
+	"github.com/beiriannydd/useragent"
 	"golang.org/x/net/html"
 )
+
+var clientUserAgent = useragent.NewUserAgent("aws-okta/1.0")
 
 type DuoClient struct {
 	Host       string
@@ -267,6 +270,7 @@ func (d *DuoClient) DoAuth(tx string, inputSid string, inputCertsURL string) (si
 
 	req.Header.Add("Origin", "https://"+d.Host)
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Add("User-Agent", clientUserAgent.String())
 
 	res, err := client.Do(req)
 	if err != nil {
@@ -341,6 +345,7 @@ func (d *DuoClient) DoU2FPromptFinish(sid string, sessionID string, resp *u2fhos
 	req.Header.Add("Origin", "https://"+d.Host)
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Add("X-Requested-With", "XMLHttpRequest")
+	req.Header.Add("User-Agent", clientUserAgent.String())
 
 	res, err := client.Do(req)
 	if err != nil {
@@ -404,6 +409,7 @@ func (d *DuoClient) DoPrompt(sid string) (txid string, err error) {
 	req.Header.Add("Origin", "https://"+d.Host)
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Add("X-Requested-With", "XMLHttpRequest")
+	req.Header.Add("User-Agent", clientUserAgent.String())
 
 	res, err := client.Do(req)
 	if err != nil {
@@ -444,6 +450,7 @@ func (d *DuoClient) DoStatus(txid, sid string) (auth string, status StatusResp, 
 	req.Header.Add("Origin", "https://"+d.Host)
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Add("X-Requested-With", "XMLHttpRequest")
+	req.Header.Add("User-Agent", clientUserAgent.String())
 
 	res, err := client.Do(req)
 	if err != nil {
@@ -480,6 +487,7 @@ func (d *DuoClient) DoRedirect(url string, sid string) (string, error) {
 	req.Header.Add("Origin", "https://"+d.Host)
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	req.Header.Add("X-Requested-With", "XMLHttpRequest")
+	req.Header.Add("User-Agent", clientUserAgent.String())
 
 	res, err := client.Do(req)
 	if err != nil {
@@ -521,6 +529,7 @@ func (d *DuoClient) DoCallback(auth string) (err error) {
 	}
 
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Add("User-Agent", clientUserAgent.String())
 
 	res, err := client.Do(req)
 	if err != nil {

--- a/vendor/github.com/beiriannydd/useragent/.gitignore
+++ b/vendor/github.com/beiriannydd/useragent/.gitignore
@@ -1,0 +1,2 @@
+useragent.test
+useragent

--- a/vendor/github.com/beiriannydd/useragent/LICENSE
+++ b/vendor/github.com/beiriannydd/useragent/LICENSE
@@ -1,0 +1,19 @@
+Copyright (c) 2020 Faye Salwin, BlackRock
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE
+OR OTHER DEALINGS IN THE SOFTWARE.

--- a/vendor/github.com/beiriannydd/useragent/README.md
+++ b/vendor/github.com/beiriannydd/useragent/README.md
@@ -1,0 +1,35 @@
+useragent
+=========
+[![GoDoc](https://godoc.org/github.com/beiriannydd/useragent?status.svg)](https://godoc.org/github.com/beiriannydd/useragent)
+[![GolangCI](https://golangci.com/badges/github.com/beiriannydd/useragent.svg)](https://golangci.com)
+[![License](https://img.shields.io/github/license/beiriannydd/useragent)](/LICENSE)
+[![Release](https://img.shields.io/github/release/beiriannydd/useragent.svg)](https://github.com/beiriannydd/useragent/releases/latest)
+
+
+A better user agent string for web requests.
+
+You may want to be able to tell what OS/Arch is being used for your requests.
+You may want to be able to have something more specific than "Go-http-client/1.1"
+
+`agent := useragent.DefaultUserAgent` will return the default User-Agent string with the addition of
+some architecture specific strings from Mozilla/Chrome in parenthesis.
+
+If you want to add more information about your client
+
+`agent := useragent.NewUserAgent("myagent/1.0", "client/2.5 (myagent)")` can be used like DefaultUserAgent.
+
+The `UserAgent` struct implements the `Stringer` interface `func String() string`.
+
+    import (
+      "net/http"
+      "os"
+
+      "github.com/beiriannydd/useragent"
+    )
+
+    func main() {
+      agent := useragent.NewUserAgent("myagent/1.0", "client/2.5 (myagent)")
+      req := http.NewRequest("GET","/",nil)
+      req.Header.Add("User-Agent", agent.String())
+      req.Write(os.Stdout)
+    }

--- a/vendor/github.com/beiriannydd/useragent/arch_darwin.go
+++ b/vendor/github.com/beiriannydd/useragent/arch_darwin.go
@@ -1,0 +1,46 @@
+package useragent
+
+import (
+	"runtime"
+	"strings"
+)
+
+func currentArchitecture() string {
+	var convert = map[string]string{
+		"amd64":    "Intel",
+		"amd64p32": "Intel",
+		"386":      "Intel",
+		"ppc":      "PPC",
+		"ppc64":    "PPC",
+		"ppc64le":  "PPC",
+		"arm":      "Mobile",
+		"arm64":    "Mobile",
+	}
+	// defaults (better than nothing)
+	os := "darwin"
+	arch := runtime.GOARCH
+	// sw_vers shows the OS name and version for Mac OS X.
+	out, _ := run("sw_vers")
+	if len(out) >= 2 {
+		parsed := map[string]string{}
+		for _, line := range out {
+			// results are Key: Value
+			fields := strings.SplitN(line, ":", 2)
+			key := strings.TrimSpace(fields[0])
+			val := strings.TrimSpace(fields[1])
+			parsed[key] = val
+		}
+		if val, found := parsed["ProductName"]; found {
+			os = val
+		}
+		if val, found := parsed["ProductVersion"]; found {
+			os = os + " " + val
+		}
+
+	}
+	if replace, found := convert[arch]; found {
+		// overrides for arch.
+		arch = replace
+	}
+	return "Macintosh; " + arch + " " + os
+}

--- a/vendor/github.com/beiriannydd/useragent/arch_linux.go
+++ b/vendor/github.com/beiriannydd/useragent/arch_linux.go
@@ -1,0 +1,28 @@
+package useragent
+
+import (
+	"runtime"
+	"strings"
+)
+
+func currentArchitecture() string {
+	var convert = map[string]string{
+		"amd64": "x86_64",
+	}
+	// defaults (better than nothing)
+	os := "Linux"
+	arch := runtime.GOARCH
+	// uname -a gives everything we need
+	out, _ := run("uname", "-a")
+	if len(out) == 1 {
+		// split into fields by whitespace
+		fields := strings.Fields(out[0])
+		os = fields[0]
+		arch = fields[11]
+	}
+	if replace, found := convert[arch]; found {
+		// overrides for arch.
+		arch = replace
+	}
+	return os + " " + arch
+}

--- a/vendor/github.com/beiriannydd/useragent/arch_windows.go
+++ b/vendor/github.com/beiriannydd/useragent/arch_windows.go
@@ -1,0 +1,30 @@
+package useragent
+
+import (
+	"runtime"
+)
+
+func currentArchitecture() string {
+	// overrides for arch output
+	var convert = map[string]string{
+		"amd64":    "; Win64; x64",
+		"amd64p32": "; Win64; x64",
+		"386":      "",
+		"arm64":    "; Win64; arm64",
+	}
+	// defaults (better than nothing)
+	os := "Windows"
+	arch := runtime.GOARCH
+	// ver outputs the OS Version
+	out, _ := run("cmd", "ver")
+	// There's a second line which is a copyright message.
+	if len(out) >= 1 {
+		// moved parsing the version out to shared code to simplify testing
+		os = parseWindowsVersion(out[0])
+	}
+	if replace, found := convert[arch]; found {
+		// overrides for arch.
+		arch = replace
+	}
+	return os + arch
+}

--- a/vendor/github.com/beiriannydd/useragent/go.mod
+++ b/vendor/github.com/beiriannydd/useragent/go.mod
@@ -1,0 +1,3 @@
+module github.com/beiriannydd/useragent
+
+go 1.14

--- a/vendor/github.com/beiriannydd/useragent/shared.go
+++ b/vendor/github.com/beiriannydd/useragent/shared.go
@@ -1,0 +1,95 @@
+// Package useragent provides an extension to the go default User-Agent string
+// including OS/Architecture by default and allowing you to easily add more
+// detail about your specific client.
+package useragent
+
+import (
+	"bufio"
+	"bytes"
+	"net/http"
+	"os/exec"
+	"strings"
+)
+
+// UserAgent is the structure we use to store our user agent string information
+type UserAgent struct {
+	Base,
+	Architecture string
+	Additional []string
+}
+
+// DefaultUserAgent is a default user agent
+var DefaultUserAgent = UserAgent{
+	Base:         defaultHTTPClientUserAgent(),
+	Architecture: currentArchitecture(),
+}
+
+// NewUserAgent returns a new UserAgent with the additionals specified
+func NewUserAgent(additional ...string) *UserAgent {
+	newagent := DefaultUserAgent
+	newagent.Additional = additional
+	return &newagent
+}
+
+// String implements Stringer interface
+func (agent *UserAgent) String() string {
+	out := agent.Base + " "
+	out = out + "(" + agent.Architecture + ")"
+	for _, additional := range agent.Additional {
+		out = out + " " + additional
+	}
+	return out
+}
+
+// This is here to allow testing on non windows platform
+func parseWindowsVersion(ver string) string {
+	// split the version string into fields by whitespace
+	fields := strings.Fields(ver)
+	val := fields[0]
+	os := "Windows"
+	// Old versions of Windows just output a version here.
+	if len(fields) > 3 {
+		os = "Windows NT"
+		val = fields[3]
+	}
+	// the last split contains junk we don't want
+	parts := strings.SplitN(val, ".", 3)
+	return os + " " + parts[0] + "." + parts[1]
+}
+
+// convenience wrapper for system() like functionality
+
+// run executs a commnd and returns stdout as an array of strings by line
+func run(command string, parameters ...string) ([]string, error) {
+	cmd := exec.Command(command, parameters...)
+	output, err := cmd.Output()
+	if err == nil {
+		result := []string{}
+		// line scanning is default behavior
+		lineScanner := bufio.NewScanner(bytes.NewReader(output))
+		lineScanner.Split(bufio.ScanLines)
+		for lineScanner.Scan() {
+			result = append(result, lineScanner.Text())
+		}
+		return result, nil
+	}
+	// err is returned if the command was unsuccessful
+	return nil, err
+}
+
+// defaultHTTPClientUserAgent loops back a request through a buffer so that we can extract the
+// private default UserAgent from Go
+func defaultHTTPClientUserAgent() string {
+	// I could use an empty string for the first 2 arguments, but that behavior could change
+	req, _ := http.NewRequest("GET", "/", nil)
+	out := bytes.Buffer{}
+	err := req.Write(&out)
+	if err != nil {
+		// something very funky happened if we got an error
+		panic(err)
+	}
+	// then read the request back
+	req, _ = http.ReadRequest(bufio.NewReader(&out))
+	// and finally return the user agent.
+	return req.Header.Get("User-Agent")
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -35,6 +35,8 @@ github.com/aws/aws-sdk-go/private/protocol/rest
 github.com/aws/aws-sdk-go/private/protocol/xml/xmlutil
 github.com/aws/aws-sdk-go/service/sts
 github.com/aws/aws-sdk-go/service/sts/stsiface
+# github.com/beiriannydd/useragent v1.0.2
+github.com/beiriannydd/useragent
 # github.com/danieljoos/wincred v1.0.2
 github.com/danieljoos/wincred
 # github.com/davecgh/go-spew v1.1.1


### PR DESCRIPTION
I raised this issue against segmentio/aws-okta where it was suggested I submit here.

We recently switched to our corporate Duo where OS blocking was in effect.  This code change enabled us to leave the "OtherOS" setting disabled.  It follows existing browser useragent OS/Arch specifiers.

Thanks!