### PR TITLE
Allow keyring prompt to be provided by environment variable

### DIFF
--- a/lib/keyring.go
+++ b/lib/keyring.go
@@ -7,6 +7,10 @@ import (
 )
 
 func keyringPrompt(prompt string) (string, error) {
+	if password := os.Getenv("AWS_OKTA_FILE_PASSPHRASE") {
+		return password, nil
+	}
+
 	return PromptWithOutput(prompt, true, os.Stderr)
 }
 


### PR DESCRIPTION
This allows a user to provide the keyring file backend with a passphrase via environment variable. This is nearly identical to a previous [feature keyring](https://github.com/99designs/keyring/pull/9/files#diff-21ce9dcd10d134f8b0f327ac1ee4aa4dL19) used to have, but has been removed and expected that wrappers provide their own interface (for example (aws-vault has this)[https://github.com/99designs/aws-vault/blob/3c14c495894b4ee2f3485d6cb9383974ae3c728b/cli/global.go#L131]).

This was a quick change to see how difficult this would be, also considering the original projects hiatus, check out who is managing/maintaining this fork. Hope someone can take a look and provide feedback! Thanks!